### PR TITLE
Don't link SalesforceSDKCore framework in static library

### DIFF
--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -46,7 +46,6 @@
 		CCC24EC50A13E34D00A6D3E3 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EBE0A13E34D00A6D3E3 /* main.m */; };
 		CCC24EC70A13E34D00A6D3E3 /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EC00A13E34D00A6D3E3 /* FMResultSet.m */; };
 		CE0021CE1C066CF80079DCA4 /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0021C51C066C1F0079DCA4 /* SalesforceSDKCore.framework */; };
-		CE0AB0CC1C10F46200BFAEED /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0021C51C066C1F0079DCA4 /* SalesforceSDKCore.framework */; };
 		CE6113641C06A01700D5A940 /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBA0A13E34D00A6D3E3 /* FMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE90C1041C06A7F800CC660F /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 8314AF3218CD73D600EC0E25 /* FMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE90C1051C06A7F800CC660F /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBA0A13E34D00A6D3E3 /* FMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -103,13 +102,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = 82D4642419C7C8170006BDFE;
 			remoteInfo = SalesforceSDKCoreTestApp;
-		};
-		CE0021CA1C066C1F0079DCA4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CE0021BC1C066C1E0079DCA4 /* SalesforceSDKCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 82D4644319C7C8180006BDFE;
-			remoteInfo = SalesforceSDKCoreTestAppTests;
 		};
 		CE0021CC1C066CE90079DCA4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -239,7 +231,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE0AB0CC1C10F46200BFAEED /* SalesforceSDKCore.framework in Frameworks */,
 				6290CBB7188FE836009790F8 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -451,9 +442,8 @@
 			isa = PBXGroup;
 			children = (
 				CE0021C51C066C1F0079DCA4 /* SalesforceSDKCore.framework */,
-				CE0021C71C066C1F0079DCA4 /* SalesforceSDKCoreTests.xctest */,
 				CE0021C91C066C1F0079DCA4 /* SalesforceSDKCoreTestApp.app */,
-				CE0021CB1C066C1F0079DCA4 /* SalesforceSDKCoreTestAppTests.xctest */,
+				CE0021C71C066C1F0079DCA4 /* SalesforceSDKCoreTests.xctest */,
 				CEA884C81C1A24B1008D871B /* libSalesforceSDKCore.a */,
 			);
 			name = Products;
@@ -660,13 +650,6 @@
 			fileType = wrapper.application;
 			path = SalesforceSDKCoreTestApp.app;
 			remoteRef = CE0021C81C066C1F0079DCA4 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		CE0021CB1C066C1F0079DCA4 /* SalesforceSDKCoreTestAppTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = SalesforceSDKCoreTestAppTests.xctest;
-			remoteRef = CE0021CA1C066C1F0079DCA4 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		CEA884C81C1A24B1008D871B /* libSalesforceSDKCore.a */ = {


### PR DESCRIPTION
Linking a private framework isn't useful in a static library.  This squashes a warning to that effect.  The target dependency is still there.