### PR TITLE
Modified FMDB to work with SQLCipher when consumed as a Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,12 @@ import PackageDescription
 let package = Package(
     name: "FMDB",
     platforms: [
-        .iOS(.v13),
-        .macOS(.v10_13),
+        .macOS(.v10_14),
+	.iOS(.v13),
+	.macCatalyst(.v13),
+	.watchOS(.v8),
+	.tvOS(.v15),
+	.visionOS(.v1)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .target(
             name: "FMDB",
             dependencies: [
-                .product(name: "SQLCipher", package: "sqlcipher")
+                .product(name: "SQLCipher", package: "SQLCipher.swift")
             ],
             path: "src/fmdb",
 	    resources: [.process("../../privacy/PrivacyInfo.xcprivacy")],

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "FMDB",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v13),
         .macOS(.v10_13),
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         // Add SQLCipher SPM dependency
-        .package(url: "https://github.com/sqlcipher/SQLCipher.swift.git", exact: "4.10.0")
+        .package(url: "https://github.com/sqlcipher/SQLCipher.swift.git", from: "4.10.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -5,22 +5,32 @@ import PackageDescription
 
 let package = Package(
     name: "FMDB",
+    platforms: [
+        .iOS(.v12),
+        .macOS(.v10_13),
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(name: "FMDB", targets: ["FMDB"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        // Add SQLCipher SPM dependency
+        .package(url: "https://github.com/sqlcipher/SQLCipher.swift.git", exact: "4.10.0")
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "FMDB",
-            dependencies: [],
+            dependencies: [
+                .product(name: "SQLCipher", package: "sqlcipher")
+            ],
             path: "src/fmdb",
-            resources: [.process("../../privacy/PrivacyInfo.xcprivacy")],
-            publicHeadersPath: "."),
+	    resources: [.process("../../privacy/PrivacyInfo.xcprivacy")],
+            publicHeadersPath: ".",
+            cSettings: [
+                .define("SQLITE_HAS_CODEC"),
+                .define("HAVE_USLEEP", to: "1"),
+                .define("SQLCIPHER_CRYPTO")
+            ]
+        )
     ]
 )

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -2,11 +2,7 @@
 #import <unistd.h>
 #import <objc/runtime.h>
 
-#if FMDB_SQLITE_STANDALONE
-#import <sqlite3/sqlite3.h>
-#else
-#import <sqlite3.h>
-#endif
+@import SQLCipher;
 
 // MARK: - FMDatabase Private Extension
 

--- a/src/fmdb/FMDatabaseAdditions.m
+++ b/src/fmdb/FMDatabaseAdditions.m
@@ -10,11 +10,7 @@
 #import "FMDatabaseAdditions.h"
 #import "TargetConditionals.h"
 
-#if FMDB_SQLITE_STANDALONE
-#import <sqlite3/sqlite3.h>
-#else
-#import <sqlite3.h>
-#endif
+@import SQLCipher;
 
 @interface FMDatabase (PrivateStuff)
 - (FMResultSet * _Nullable)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray * _Nullable)arrayArgs orDictionary:(NSDictionary * _Nullable)dictionaryArgs orVAList:(va_list)args shouldBind:(BOOL)shouldBind;

--- a/src/fmdb/FMDatabasePool.m
+++ b/src/fmdb/FMDatabasePool.m
@@ -6,11 +6,7 @@
 //  Copyright 2011 Flying Meat Inc. All rights reserved.
 //
 
-#if FMDB_SQLITE_STANDALONE
-#import <sqlite3/sqlite3.h>
-#else
-#import <sqlite3.h>
-#endif
+@import SQLCipher;
 
 #import "FMDatabasePool.h"
 #import "FMDatabase.h"

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -2,11 +2,7 @@
 #import "FMDatabase.h"
 #import <unistd.h>
 
-#if FMDB_SQLITE_STANDALONE
-#import <sqlite3/sqlite3.h>
-#else
-#import <sqlite3.h>
-#endif
+@import SQLCipher;
 
 // MARK: - FMDatabase Private Extension
 


### PR DESCRIPTION
SQLCipher just added SPM support in 4.10.0 and FMDB has had it for a while.

That means: 
- we can get rid of the FMDB sub module in the SalesforceMobileSDK-iOS repo
- we no longer need to build and check in the SQLCipher framework

In the FMDB pod spec, there is a sub spec to make it link with SQLCipher which defines additional compiler flags and also specify a different header path (so that it does not use the system sqlite3.h).

Unfortunately there is not equivalent to that in the package.swift.

To address these gaps, I brought back our FMDB fork and modified the Package.swift there to do the right thing.
I also changed some import statements in key classes.